### PR TITLE
Add dataset, model, training and evaluation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,21 @@ This project explores using a neural network to evaluate **Magic: The Gathering*
 4. **Preprocess data** – tokenize oracle text and encode card metadata.
 5. **Train a neural network** – an LSTM encoder processes text while structured features are concatenated and fed through dense layers.
 
-See `src/pipeline.py` for a placeholder implementation with mock card data.
 `src/ingest_cards.py` demonstrates how to download real card details from
 the Scryfall API and save them to `card_data.csv` with a basic
-`strength_score` column. Future iterations can merge this data with
-tournament win rates.
+`strength_score` column. `src/train.py` trains the neural network on this
+dataset and stores the best model checkpoint in the `checkpoints/` folder.
+`src/evaluate.py` loads the saved model and reports prediction metrics on the
+full dataset. Future iterations can merge this data with tournament win
+rates.
 
 ## Running
 
 ```bash
 pip install -r requirements.txt
-python src/pipeline.py  # train on mock data
-python src/ingest_cards.py  # fetch real card data
+python src/ingest_cards.py      # fetch real card data
+python src/train.py --epochs 5  # train the model
+python src/evaluate.py          # evaluate the checkpoint
 ```
-
-The script will run a tiny training loop on example data.
+The training script saves its best weights to `checkpoints/best_model.pt` and
+`evaluate.py` will report basic metrics against the full dataset.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,16 @@
+# Default configuration for training and evaluation
+
+paths:
+  data: card_data.csv
+  checkpoint_dir: checkpoints
+
+training:
+  epochs: 5
+  batch_size: 16
+  learning_rate: 0.001
+  seed: 42
+
+model:
+  embed_dim: 32
+  lstm_dim: 32
+  hidden_dim: 64

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,0 +1,102 @@
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from typing import Tuple, Dict, List, Optional
+from torch.utils.data import Dataset
+import torch
+
+
+def tokenize(text: str) -> List[str]:
+    return text.lower().replace(',', ' ').replace('.', ' ').split()
+
+
+def build_vocab(texts: List[str]) -> Dict[str, int]:
+    tokens = sorted({tok for text in texts for tok in tokenize(text)})
+    return {tok: idx + 1 for idx, tok in enumerate(tokens)}  # reserve 0 for PAD
+
+
+def encode_text(text: str, vocab: Dict[str, int]) -> List[int]:
+    return [vocab.get(tok, 0) for tok in tokenize(text)]
+
+
+class CardDataset(Dataset):
+    """PyTorch dataset for MTG card strength prediction."""
+
+    def __init__(self, df: pd.DataFrame, vocab: Optional[Dict[str, int]] = None,
+                 cat_maps: Optional[Dict[str, Dict[str, int]]] = None,
+                 scaler: Optional[Dict[str, pd.Series]] = None):
+        self.df = df.reset_index(drop=True)
+        self.texts = self.df.get('oracle_text', '').fillna('').astype(str).tolist()
+
+        # Build vocab from provided texts if not given
+        self.vocab = vocab or build_vocab(self.texts)
+        tokens = [encode_text(t, self.vocab) for t in self.texts]
+        self.tokenized = [tok if len(tok) > 0 else [0] for tok in tokens]
+
+        # Numeric columns
+        num_cols = ['mana_cost', 'power', 'toughness']
+        self.df[num_cols] = self.df[num_cols].fillna(0).astype(float)
+        if scaler is None:
+            means = self.df[num_cols].mean()
+            stds = self.df[num_cols].std().replace(0, 1)
+            self.scaler = {'mean': means, 'std': stds}
+        else:
+            self.scaler = scaler
+        self.df[num_cols] = (self.df[num_cols] - self.scaler['mean']) / self.scaler['std']
+        self.numeric = self.df[num_cols].values.astype('float32')
+
+        # Categorical columns
+        cat_cols = ['rarity', 'type_line']
+        self.df[cat_cols] = self.df[cat_cols].fillna('unknown').astype(str)
+        if cat_maps is None:
+            self.cat_maps = {
+                col: {v: i for i, v in enumerate(sorted(self.df[col].unique()))}
+                for col in cat_cols
+            }
+        else:
+            self.cat_maps = cat_maps
+        cat_feats = []
+        for col in cat_cols:
+            mapping = self.cat_maps[col]
+            idxs = self.df[col].map(lambda x: mapping.get(x, 0)).astype(int).values
+            one_hot = np.eye(len(mapping))[idxs]
+            cat_feats.append(one_hot)
+        self.categorical = np.concatenate(cat_feats, axis=1).astype('float32')
+
+        self.labels = self.df['strength_score'].fillna(0).astype('float32').values
+        self.feature_dim = self.numeric.shape[1] + self.categorical.shape[1]
+
+    def __len__(self) -> int:
+        return len(self.df)
+
+    def __getitem__(self, idx: int):
+        text_ids = self.tokenized[idx]
+        struct = np.concatenate([self.numeric[idx], self.categorical[idx]])
+        label = self.labels[idx]
+        return text_ids, struct, label
+
+
+def collate_fn(batch):
+    texts, structs, labels = zip(*batch)
+    lengths = torch.tensor([len(t) for t in texts], dtype=torch.long)
+    padded_texts = torch.nn.utils.rnn.pad_sequence(
+        [torch.tensor(t) for t in texts], batch_first=True
+    )
+    struct_tensor = torch.tensor(structs, dtype=torch.float32)
+    label_tensor = torch.tensor(labels, dtype=torch.float32).unsqueeze(1)
+    return padded_texts, lengths, struct_tensor, label_tensor
+
+
+def load_train_val_split(test_size: float = 0.2, seed: int = 42) -> Tuple[CardDataset, CardDataset]:
+    """Load ``card_data.csv`` and return train/validation datasets."""
+    path = Path('card_data.csv')
+    df = pd.read_csv(path)
+    np.random.seed(seed)
+    indices = np.random.permutation(len(df))
+    split = int(len(df) * (1 - test_size))
+    train_idx, val_idx = indices[:split], indices[split:]
+    train_df = df.iloc[train_idx].reset_index(drop=True)
+    val_df = df.iloc[val_idx].reset_index(drop=True)
+    train_ds = CardDataset(train_df)
+    val_ds = CardDataset(val_df, vocab=train_ds.vocab, cat_maps=train_ds.cat_maps, scaler=train_ds.scaler)
+    return train_ds, val_ds

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,0 +1,60 @@
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader
+import matplotlib.pyplot as plt
+
+from data_loader import CardDataset, collate_fn, load_train_val_split
+from model import CardStrengthPredictor
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate trained model")
+    parser.add_argument("--checkpoint", type=str, default="checkpoints/best_model.pt")
+    args = parser.parse_args()
+
+    # Build preprocessing using the original training split
+    train_ds, _ = load_train_val_split()
+    full_df = pd.read_csv("card_data.csv")
+    dataset = CardDataset(full_df, vocab=train_ds.vocab, cat_maps=train_ds.cat_maps, scaler=train_ds.scaler)
+    loader = DataLoader(dataset, batch_size=32, shuffle=False, collate_fn=collate_fn)
+
+    model = CardStrengthPredictor(len(train_ds.vocab), dataset.feature_dim)
+    model.load_state_dict(torch.load(args.checkpoint, map_location="cpu"))
+    model.eval()
+
+    preds, labels = [], []
+    with torch.no_grad():
+        for text, lengths, feats, labs in loader:
+            out = model(text, lengths, feats).squeeze(1)
+            preds.extend(out.numpy())
+            labels.extend(labs.squeeze(1).numpy())
+    preds = np.array(preds)
+    labels = np.array(labels)
+
+    corr = float(np.corrcoef(labels, preds)[0, 1])
+    mae = float(np.mean(np.abs(labels - preds)))
+    print(f"Pearson correlation: {corr:.4f}")
+    print(f"MAE: {mae:.4f}")
+
+    plt.scatter(labels, preds, alpha=0.5)
+    plt.xlabel("Actual Strength")
+    plt.ylabel("Predicted Strength")
+    plt.savefig("pred_vs_actual.png")
+
+    diff = preds - labels
+    order = np.argsort(diff)
+    over_idx = order[-10:][::-1]
+    under_idx = order[:10]
+    df = dataset.df
+    print("Top 10 over-performing predictions:")
+    print(df.iloc[over_idx][["name", "strength_score"]])
+    print("Top 10 under-performing predictions:")
+    print(df.iloc[under_idx][["name", "strength_score"]])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model.py
+++ b/src/model.py
@@ -1,0 +1,28 @@
+import torch
+from torch import nn
+from torch.nn.utils.rnn import pack_padded_sequence
+
+
+class CardStrengthPredictor(nn.Module):
+    """LSTM-based model for card strength prediction."""
+
+    def __init__(self, vocab_size: int, feature_dim: int, embed_dim: int = 32,
+                 lstm_dim: int = 32, hidden_dim: int = 64):
+        super().__init__()
+        self.text_emb = nn.Embedding(vocab_size + 1, embed_dim, padding_idx=0)
+        self.lstm = nn.LSTM(embed_dim, lstm_dim, batch_first=True)
+        self.fc = nn.Sequential(
+            nn.Linear(lstm_dim + feature_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, text_tokens: torch.Tensor, lengths: torch.Tensor,
+                features: torch.Tensor) -> torch.Tensor:
+        embedded = self.text_emb(text_tokens)
+        packed = pack_padded_sequence(embedded, lengths, batch_first=True,
+                                      enforce_sorted=False)
+        _, (hidden, _) = self.lstm(packed)
+        text_vec = hidden[-1]
+        x = torch.cat([text_vec, features], dim=1)
+        return self.fc(x)

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,83 @@
+import argparse
+from pathlib import Path
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+from data_loader import load_train_val_split, collate_fn
+from model import CardStrengthPredictor
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train card strength model")
+    parser.add_argument("--epochs", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--embed-dim", type=int, default=32)
+    parser.add_argument("--lstm-dim", type=int, default=32)
+    parser.add_argument("--hidden-dim", type=int, default=64)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--checkpoint-dir", type=str, default="checkpoints")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    torch.manual_seed(args.seed)
+
+    train_ds, val_ds = load_train_val_split(seed=args.seed)
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True,
+                              collate_fn=collate_fn)
+    val_loader = DataLoader(val_ds, batch_size=args.batch_size, shuffle=False,
+                            collate_fn=collate_fn)
+
+    model = CardStrengthPredictor(len(train_ds.vocab), train_ds.feature_dim,
+                                  embed_dim=args.embed_dim,
+                                  lstm_dim=args.lstm_dim,
+                                  hidden_dim=args.hidden_dim)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    loss_fn = nn.MSELoss()
+
+    best_loss = float("inf")
+    ckpt_dir = Path(args.checkpoint_dir)
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    for epoch in range(args.epochs):
+        model.train()
+        train_losses = []
+        for text, lengths, feats, labels in train_loader:
+            text, lengths = text.to(device), lengths.to(device)
+            feats, labels = feats.to(device), labels.to(device)
+            optimizer.zero_grad()
+            preds = model(text, lengths, feats)
+            loss = loss_fn(preds, labels)
+            loss.backward()
+            optimizer.step()
+            train_losses.append(loss.item())
+
+        model.eval()
+        val_losses = []
+        with torch.no_grad():
+            for text, lengths, feats, labels in val_loader:
+                text, lengths = text.to(device), lengths.to(device)
+                feats, labels = feats.to(device), labels.to(device)
+                preds = model(text, lengths, feats)
+                loss = loss_fn(preds, labels)
+                val_losses.append(loss.item())
+        train_loss = sum(train_losses) / len(train_losses)
+        val_loss = sum(val_losses) / len(val_losses)
+        print(f"Epoch {epoch + 1}/{args.epochs} train_loss={train_loss:.4f} val_loss={val_loss:.4f}")
+
+        if val_loss < best_loss:
+            best_loss = val_loss
+            torch.save(model.state_dict(), ckpt_dir / "best_model.pt")
+
+    print(f"Best validation loss: {best_loss:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `CardDataset` for preprocessing in `data_loader.py`
- add `CardStrengthPredictor` model
- create `train.py` and `evaluate.py` scripts
- document new workflow in README
- provide sample configuration in `config.yaml`

## Testing
- `python -m py_compile src/ingest_cards.py src/pipeline.py src/data_loader.py src/model.py src/train.py src/evaluate.py`
- `python src/ingest_cards.py`
- `python src/train.py --epochs 1`
- `python src/evaluate.py --checkpoint checkpoints/best_model.pt`

------
https://chatgpt.com/codex/tasks/task_e_685af0af551c8327a656959cdf976db0