### PR TITLE
Add config support for training and evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ rates.
 
 ```bash
 pip install -r requirements.txt
-python src/ingest_cards.py      # fetch real card data
-python src/train.py --epochs 5  # train the model
-python src/evaluate.py          # evaluate the checkpoint
+python src/ingest_cards.py          # fetch real card data
+python src/train.py                 # train the model using config.yaml
+python src/evaluate.py              # evaluate the checkpoint
 ```
 The training script saves its best weights to `checkpoints/best_model.pt` and
-`evaluate.py` will report basic metrics against the full dataset.
+`evaluate.py` will report basic metrics against the full dataset. Parameters can
+be adjusted in `config.yaml` or overridden on the command line.

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -87,9 +87,11 @@ def collate_fn(batch):
     return padded_texts, lengths, struct_tensor, label_tensor
 
 
-def load_train_val_split(test_size: float = 0.2, seed: int = 42) -> Tuple[CardDataset, CardDataset]:
-    """Load ``card_data.csv`` and return train/validation datasets."""
-    path = Path('card_data.csv')
+def load_train_val_split(
+    path: str | Path = "card_data.csv", test_size: float = 0.2, seed: int = 42
+) -> Tuple[CardDataset, CardDataset]:
+    """Load a CSV file and return train/validation ``CardDataset`` objects."""
+    path = Path(path)
     df = pd.read_csv(path)
     np.random.seed(seed)
     indices = np.random.permutation(len(df))


### PR DESCRIPTION
## Summary
- parse `config.yaml` in training and evaluation scripts
- allow overriding parameters from the config file
- update evaluation to report largest errors instead of over/under lists
- expose dataset path in `load_train_val_split`
- document config usage in README

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685b0c6d671c8327b71aa307ff105d0a