### PR TITLE
Modular data loading and model modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ them to `card_data.csv` with a placeholder `strength_score`.
 cards with the mean win rate, and overwrites the `strength_score` column. The
 merged data is written back to `card_data.csv`.
 `src/train.py` trains the neural network on this dataset and stores the best
-model checkpoint in the `checkpoints/` folder. `src/evaluate.py` loads the
-saved model and reports prediction metrics on the full dataset.
+model checkpoint in the `checkpoints/` folder. Data loading and model
+definitions live in `src/data_loader.py` and `src/model.py` so they can be
+reused across scripts. `src/evaluate.py` loads the saved model and reports
+prediction metrics on the full dataset.
 
 ## Running
 

--- a/src/model.py
+++ b/src/model.py
@@ -1,28 +1,53 @@
+"""Neural network model for predicting card strength."""
+
+from __future__ import annotations
+
+from typing import Dict
+
 import torch
 from torch import nn
-from torch.nn.utils.rnn import pack_padded_sequence
 
 
 class CardStrengthPredictor(nn.Module):
-    """LSTM-based model for card strength prediction."""
+    """Model combining text and structured card features."""
 
-    def __init__(self, vocab_size: int, feature_dim: int, embed_dim: int = 32,
-                 lstm_dim: int = 32, hidden_dim: int = 64):
+    def __init__(self, vocab_size: int, feature_dim: int, config: Dict | None = None) -> None:
+        config = config or {}
         super().__init__()
-        self.text_emb = nn.Embedding(vocab_size + 1, embed_dim, padding_idx=0)
+
+        embed_dim = config.get("embed_dim", 32)
+        lstm_dim = config.get("lstm_dim", 32)
+        dense_units = config.get("hidden_dim", 64)
+        dropout = config.get("dropout_rate", 0.0)
+
+        # Text embedding followed by a single LSTM layer
+        self.embedding = nn.Embedding(vocab_size + 1, embed_dim, padding_idx=0)
         self.lstm = nn.LSTM(embed_dim, lstm_dim, batch_first=True)
-        self.fc = nn.Sequential(
-            nn.Linear(lstm_dim + feature_dim, hidden_dim),
+
+        # Linear projection for structured numeric/categorical features
+        self.feature_proj = nn.Linear(feature_dim, dense_units)
+
+        # Final regression network
+        self.regressor = nn.Sequential(
             nn.ReLU(),
-            nn.Linear(hidden_dim, 1),
+            nn.Dropout(dropout),
+            nn.Linear(lstm_dim + dense_units, dense_units),
+            nn.ReLU(),
+            nn.Linear(dense_units, 1),
         )
 
-    def forward(self, text_tokens: torch.Tensor, lengths: torch.Tensor,
-                features: torch.Tensor) -> torch.Tensor:
-        embedded = self.text_emb(text_tokens)
-        packed = pack_padded_sequence(embedded, lengths, batch_first=True,
-                                      enforce_sorted=False)
-        _, (hidden, _) = self.lstm(packed)
+    def forward(self, features: torch.Tensor, text_tokens: torch.Tensor) -> torch.Tensor:
+        """Return a strength score prediction for a batch of cards."""
+
+        # Text sequence to embedding vector using the last LSTM hidden state
+        embedded = self.embedding(text_tokens)
+        _, (hidden, _) = self.lstm(embedded)
         text_vec = hidden[-1]
-        x = torch.cat([text_vec, features], dim=1)
-        return self.fc(x)
+
+        # Project structured features into the same hidden space
+        struct_vec = self.feature_proj(features)
+
+        # Concatenate and map to a single regression output
+        x = torch.cat([text_vec, struct_vec], dim=1)
+        return self.regressor(x)
+

--- a/src/train.py
+++ b/src/train.py
@@ -4,35 +4,22 @@ import yaml
 
 import torch
 from torch import nn
-from torch.utils.data import DataLoader
 
-from data_loader import load_train_val_split, collate_fn
-from model import CardStrengthPredictor
-import csv
+from src.data_loader import load_train_val_split
+from src.model import CardStrengthPredictor
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Train card strength model")
-    parser.add_argument("--epochs", type=int, default=None)
-    parser.add_argument("--batch-size", type=int, default=None)
-    parser.add_argument("--lr", type=float, default=None)
-    parser.add_argument("--embed-dim", type=int, default=None)
-    parser.add_argument("--lstm-dim", type=int, default=None)
-    parser.add_argument("--hidden-dim", type=int, default=None)
-    parser.add_argument("--seed", type=int, default=None)
-    parser.add_argument("--checkpoint-dir", type=str, default=None)
     parser.add_argument("--config", type=str, default="config.yaml")
     return parser.parse_args()
 
 
-def train_model(train_loader, val_loader, vocab_size, feature_dim, embed_dim, lr, lstm_dim, hidden_dim, device, epochs=5, checkpoint_dir="checkpoints"):
-    """Train a model with the given hyperparameters and return final val loss."""
-    model = CardStrengthPredictor(vocab_size, feature_dim,
-                                  embed_dim=embed_dim,
-                                  lstm_dim=lstm_dim,
-                                  hidden_dim=hidden_dim)
+def train_model(train_loader, val_loader, vocab_size, feature_dim, config, device, epochs=5, checkpoint_dir="checkpoints"):
+    """Train ``CardStrengthPredictor`` and return the final validation loss."""
+    model = CardStrengthPredictor(vocab_size, feature_dim, config)
     model.to(device)
-    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.get("learning_rate", 1e-3))
     loss_fn = nn.MSELoss()
 
     ckpt_dir = Path(checkpoint_dir)
@@ -42,10 +29,10 @@ def train_model(train_loader, val_loader, vocab_size, feature_dim, embed_dim, lr
     for epoch in range(epochs):
         model.train()
         for text, lengths, feats, labels in train_loader:
-            text, lengths = text.to(device), lengths.to(device)
+            text = text.to(device)
             feats, labels = feats.to(device), labels.to(device)
             optimizer.zero_grad()
-            preds = model(text, lengths, feats)
+            preds = model(feats, text)
             loss = loss_fn(preds, labels)
             loss.backward()
             optimizer.step()
@@ -54,9 +41,9 @@ def train_model(train_loader, val_loader, vocab_size, feature_dim, embed_dim, lr
         val_losses = []
         with torch.no_grad():
             for text, lengths, feats, labels in val_loader:
-                text, lengths = text.to(device), lengths.to(device)
+                text = text.to(device)
                 feats, labels = feats.to(device), labels.to(device)
-                preds = model(text, lengths, feats)
+                preds = model(feats, text)
                 loss = loss_fn(preds, labels)
                 val_losses.append(loss.item())
         val_loss = sum(val_losses) / len(val_losses)
@@ -78,49 +65,25 @@ def main():
     model_cfg = config.get("model", {})
     paths_cfg = config.get("paths", {})
 
-    args.epochs = args.epochs or train_cfg.get("epochs", 5)
-    args.batch_size = args.batch_size or train_cfg.get("batch_size", 16)
-    args.lr = args.lr or train_cfg.get("learning_rate", 1e-3)
-    args.embed_dim = args.embed_dim or model_cfg.get("embed_dim", 32)
-    args.lstm_dim = args.lstm_dim or model_cfg.get("lstm_dim", 32)
-    args.hidden_dim = args.hidden_dim or model_cfg.get("hidden_dim", 64)
-    args.seed = args.seed or train_cfg.get("seed", 42)
-    args.checkpoint_dir = args.checkpoint_dir or paths_cfg.get("checkpoint_dir", "checkpoints")
-    data_path = paths_cfg.get("data", "card_data.csv")
+    torch.manual_seed(train_cfg.get("seed", 42))
 
-    torch.manual_seed(args.seed)
-    train_ds, val_ds = load_train_val_split(path=data_path, seed=args.seed)
-    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True,
-                              collate_fn=collate_fn)
-    val_loader = DataLoader(val_ds, batch_size=args.batch_size, shuffle=False,
-                            collate_fn=collate_fn)
+    train_loader, val_loader, dataset = load_train_val_split(
+        config, test_size=train_cfg.get("val_split", 0.2)
+    )
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    lrs = [1e-3, 1e-4]
-    embeds = [64, 128]
-
-    results_path = Path("sweep_results.csv")
-    with results_path.open("w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(["lr", "embed_dim", "val_loss"])
-        for lr in lrs:
-            for embed in embeds:
-                val_loss = train_model(
-                    train_loader,
-                    val_loader,
-                    len(train_ds.vocab),
-                    train_ds.feature_dim,
-                    embed,
-                    lr,
-                    args.lstm_dim,
-                    args.hidden_dim,
-                    device,
-                    epochs=5,
-                    checkpoint_dir=args.checkpoint_dir,
-                )
-                writer.writerow([lr, embed, f"{val_loss:.4f}"])
-                print(f"lr={lr} embed_dim={embed} val_loss={val_loss:.4f}")
+    val_loss = train_model(
+        train_loader,
+        val_loader,
+        len(dataset.vocab),
+        dataset.features.shape[1],
+        model_cfg | train_cfg,
+        device,
+        epochs=train_cfg.get("epochs", 5),
+        checkpoint_dir=paths_cfg.get("checkpoint_dir", "checkpoints"),
+    )
+    print(f"Validation loss: {val_loss:.4f}")
 
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -17,11 +17,11 @@ def test_ingest_creates_csv(tmp_path):
 
 
 def test_model_forward():
-    model = CardStrengthPredictor(vocab_size=10, feature_dim=5)
+    model = CardStrengthPredictor(vocab_size=10, feature_dim=5, config={})
     text = torch.randint(0, 10, (2, 4))
     lengths = torch.tensor([4, 4])
     feats = torch.randn(2, 5)
-    out = model(text, lengths, feats)
+    out = model(feats, text)
     assert out.shape == (2, 1)
 
 


### PR DESCRIPTION
## Summary
- refactor data_loader and model into reusable modules
- update training and evaluation scripts to import these modules
- simplify training script logic
- adjust smoke tests for new model interface
- document module locations in README

## Testing
- `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu -q`
- `pip install pandas -q`
- `pip install requests -q`
- `python src/ingest_cards.py > /tmp/ingest.log && tail -n 20 /tmp/ingest.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0114879483279fb781c581a8e16c