### PR TITLE
Add smoke tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test-and-train:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run pytest
+        run: pytest --maxfail=1 --disable-warnings -q
+
+      - name: Smoke-train for 1 epoch
+        run: python src/train.py --config config.yaml --epochs 1

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+import yaml
+import pandas as pd
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from data_loader import load_train_val_split
+
+
+def ensure_dataset_exists():
+    """Create a minimal ``card_data.csv`` file if one does not exist."""
+    data_path = Path("card_data.csv")
+    if not data_path.is_file():
+        df = pd.DataFrame(
+            [
+                {
+                    "name": "CardA",
+                    "oracle_text": "foo",
+                    "mana_value": 1,
+                    "power": 1,
+                    "toughness": 1,
+                    "appearances": 1,
+                    "rarity": "common",
+                    "type_line": "Creature",
+                    "strength_score": 1.0,
+                }
+            ]
+        )
+        df.to_csv(data_path, index=False)
+
+
+def test_dataset_loads():
+    """Dataset should load and provide non-empty splits."""
+    ensure_dataset_exists()
+    with open("config.yaml", "r") as f:
+        config = yaml.safe_load(f)
+    train_loader, val_loader, _ = load_train_val_split(config, test_size=0.2, seed=0)
+    assert len(train_loader.dataset) > 0
+    assert len(val_loader.dataset) >= 0
+
+
+def test_batch_shape():
+    """Feature batch dimension must match target batch dimension."""
+    ensure_dataset_exists()
+    with open("config.yaml", "r") as f:
+        config = yaml.safe_load(f)
+    train_loader, _, _ = load_train_val_split(config, test_size=0.2, seed=0)
+    text, lengths, feats, target = next(iter(train_loader))
+    assert feats.shape[0] == target.shape[0]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import yaml
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from data_loader import load_train_val_split
+from model import CardStrengthPredictor
+
+
+def test_forward_pass():
+    """Ensure a forward pass returns the correct output shape."""
+    with open("config.yaml", "r") as f:
+        config = yaml.safe_load(f)
+    params = config["model"]
+
+    _, _, dataset = load_train_val_split(config, test_size=0.2, seed=0)
+
+    model = CardStrengthPredictor(
+        vocab_size=len(dataset.vocab),
+        feature_dim=dataset.features.shape[1],
+        config={
+            "embed_dim": params["embed_dim"],
+            "lstm_dim": params["lstm_dim"],
+            "hidden_dim": params["hidden_dim"],
+            "dropout_rate": params.get("dropout_rate", 0.0),
+        },
+    )
+
+    dummy_tokens = torch.randint(0, len(dataset.vocab), (4, 10))
+    dummy_feats = torch.randn(4, dataset.features.shape[1])
+    out = model(dummy_feats, dummy_tokens)
+    assert out.shape == (4, 1)


### PR DESCRIPTION
## Summary
- add workflow for CI with pytest and a 1-epoch smoke train
- add tests for data loading and model forward pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c055e86b0832790eb5a47fb81c11d