### PR TITLE
Enhance features and add API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ merged data is written back to `card_data.csv`.
 `src/train.py` trains the neural network on this dataset and stores the best
 model checkpoint in the `checkpoints/` folder. Data loading and model
 definitions live in `src/data_loader.py` and `src/model.py` so they can be
-reused across scripts. `src/evaluate.py` loads the saved model and reports
-prediction metrics on the full dataset.
+reused across scripts. `src/evaluate.py` loads the saved model, writes
+`predictions.csv`, and reports prediction metrics on the full dataset.
+`src/error_analysis.py` inspects those predictions and stores the largest
+over/under-estimates in `logs/top_errors.csv`. A small FastAPI service in
+`src/api.py` exposes a `/predict` endpoint used by the web UI under `ui/`.
 
 ## Running
 

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,4 @@ model:
   embed_dim: 128
   lstm_dim: 32
   hidden_dim: 64
+  dropout_rate: 0.1

--- a/src/api.py
+++ b/src/api.py
@@ -1,53 +1,90 @@
-"""FastAPI endpoint for predicting card strength."""
+"""FastAPI API for serving card strength predictions."""
 from __future__ import annotations
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from pathlib import Path
+from typing import Optional
+
 import pandas as pd
 import torch
-from torch.utils.data import DataLoader
+import yaml
 
-from data_loader import CardDataset, collate_fn
-from model import CardStrengthPredictor
+from src.data_loader import CardDataset
+from src.model import CardStrengthPredictor
 
 app = FastAPI()
 
-DATA_PATH = Path("card_data.csv")
-CHECKPOINT_PATH = Path("checkpoints/best_model.pt")
-
-# Load preprocessing artifacts and model on startup
-if DATA_PATH.is_file() and CHECKPOINT_PATH.is_file():
-    base_df = pd.read_csv(DATA_PATH)
-    base_ds = CardDataset(base_df)
-    vocab = base_ds.vocab
-    cat_maps = base_ds.cat_maps
-    scaler = base_ds.scaler
-    model = CardStrengthPredictor(len(vocab), base_ds.feature_dim)
-    model.load_state_dict(torch.load(CHECKPOINT_PATH, map_location="cpu"))
-    model.eval()
-else:
-    raise RuntimeError("Required data/model files not found")
-
 
 class CardRequest(BaseModel):
-    name: str | None = None
-    mana_cost: float | None = 0
-    type_line: str | None = "Creature"
-    power: float | None = 0
-    toughness: float | None = 0
-    colors: str | None = ""
-    oracle_text: str | None = ""
-    rarity: str | None = "common"
+    card_name: Optional[str] = None
+    oracle_text: str = ""
+    mana_value: float = 0.0
+    type_line: str = ""
+    colors: str = ""
+    appearances: float = 0.0
+    power: float = 0.0
+    toughness: float = 0.0
+    rarity: str = "common"
+
+
+@app.on_event("startup")
+def _startup():
+    """Load preprocessing artifacts and trained model."""
+    global DATASET, MODEL
+    try:
+        with open("config.yaml", "r") as f:
+            config = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        config = {}
+
+    DATASET = CardDataset(config)
+    ckpt_dir = Path(config.get("paths", {}).get("checkpoint_dir", "checkpoints"))
+    state = torch.load(ckpt_dir / "best_model.pt", map_location="cpu")
+    MODEL = CardStrengthPredictor(len(DATASET.vocab), DATASET.feature_dim, config.get("model", {}))
+    MODEL.load_state_dict(state)
+    MODEL.eval()
+
+
+def _prepare_features(req: CardRequest) -> tuple[torch.Tensor, torch.Tensor]:
+    """Convert request data into model-ready tensors."""
+    data = req.dict()
+
+    if req.card_name:
+        match = DATASET.df[DATASET.df["name"].str.lower() == req.card_name.lower()]
+        if not match.empty:
+            base = match.iloc[0]
+            for key in [
+                "oracle_text",
+                "mana_value",
+                "type_line",
+                "colors",
+                "appearances",
+                "power",
+                "toughness",
+                "rarity",
+            ]:
+                if not data.get(key):
+                    data[key] = base.get(key, data.get(key))
+
+    row = pd.Series(data)
+    text, feats = DATASET.vectorize_row(row)
+    return text.unsqueeze(0), feats.unsqueeze(0)
 
 
 @app.post("/predict")
 def predict(card: CardRequest):
-    df = pd.DataFrame([card.dict()])
-    ds = CardDataset(df, vocab=vocab, cat_maps=cat_maps, scaler=scaler)
-    loader = DataLoader(ds, batch_size=1, collate_fn=collate_fn)
-    text, lengths, feats, _ = next(iter(loader))
+    try:
+        text, feats = _prepare_features(card)
+    except Exception as exc:  # pragma: no cover - robust against bad input
+        raise HTTPException(status_code=400, detail=str(exc))
+
     with torch.no_grad():
-        pred = model(text, lengths, feats).item()
+        pred = MODEL(feats, text).item()
     return {"strength_score": float(pred)}
 
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/error_analysis.py
+++ b/src/error_analysis.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from pathlib import Path
+
+
+def main():
+    """Compute and save top prediction errors."""
+    try:
+        card_df = pd.read_csv("card_data.csv")
+        pred_df = pd.read_csv("predictions.csv")
+    except FileNotFoundError as e:
+        raise SystemExit(f"Missing required file: {e.filename}")
+
+    df = pred_df.merge(card_df[["name", "strength_score"]], left_on="card_name", right_on="name", how="left")
+    if df["strength_score"].isna().any():
+        df = df.dropna(subset=["strength_score"])
+
+    df["error"] = df["predicted"] - df["strength_score"]
+    df["abs_error"] = df["error"].abs()
+
+    over = df.sort_values("error", ascending=False).head(20)
+    under = df.sort_values("error", ascending=True).head(20)
+
+    print("Top over-predictions:")
+    print(over[["card_name", "strength_score", "predicted", "error"]])
+
+    print("\nTop under-predictions:")
+    print(under[["card_name", "strength_score", "predicted", "error"]])
+
+    logs = Path("logs")
+    logs.mkdir(exist_ok=True)
+    out_df = pd.concat([over.assign(kind="over"), under.assign(kind="under")])
+    out_df.to_csv(logs / "top_errors.csv", index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import yaml
 
 import numpy as np
+import pandas as pd
 import torch
 import matplotlib.pyplot as plt
 
@@ -63,6 +64,16 @@ def main():
     cols = [c for c in ["name", "strength_score"] if c in df.columns]
     print("Top 10 prediction errors:")
     print(df.iloc[top_idx][cols].assign(predicted=preds[top_idx], error=abs_err[top_idx]))
+
+    # Save predictions for downstream analysis
+    pred_df = pd.DataFrame(
+        {
+            "card_name": dataset.df.get("name", pd.Series(range(len(preds)))).astype(str),
+            "strength_score": labels,
+            "predicted": preds,
+        }
+    )
+    pred_df.to_csv("predictions.csv", index=False)
 
 
 if __name__ == "__main__":

--- a/src/model.py
+++ b/src/model.py
@@ -27,12 +27,16 @@ class CardStrengthPredictor(nn.Module):
         # Linear projection for structured numeric/categorical features
         self.feature_proj = nn.Linear(feature_dim, dense_units)
 
-        # Final regression network
+        # Final regression network with an extra hidden layer
         self.regressor = nn.Sequential(
             nn.ReLU(),
             nn.Dropout(dropout),
             nn.Linear(lstm_dim + dense_units, dense_units),
             nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(dense_units, dense_units),
+            nn.ReLU(),
+            nn.Dropout(dropout),
             nn.Linear(dense_units, 1),
         )
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>MTG Card Strength</title>
+</head>
+<body>
+  <h3>Card Strength Lookup</h3>
+  <input type="text" id="cardName" placeholder="Card name" />
+  <button id="btn">Get Strength</button>
+  <div id="result"></div>
+<script>
+document.getElementById('btn').onclick = async () => {
+  const name = document.getElementById('cardName').value;
+  const res = await fetch('http://localhost:8000/predict', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({card_name: name})
+  });
+  const data = await res.json();
+  document.getElementById('result').innerText = 'Strength score: ' + data.strength_score;
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- engineer new card features and expose vectorize_row helper
- expand neural network with extra hidden layer and dropout
- output predictions.csv during evaluation and add error analysis script
- build FastAPI deployment endpoint and simple HTML UI
- document evaluation outputs and new API
- configure dropout rate in default config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0ee363d48327b58411d94005ff5a