### PR TITLE
Enhance features and transformer text encoder

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -21,7 +21,6 @@ def test_forward_pass():
         feature_dim=dataset.features.shape[1],
         config={
             "embed_dim": params["embed_dim"],
-            "lstm_dim": params["lstm_dim"],
             "hidden_dim": params["hidden_dim"],
             "dropout_rate": params.get("dropout_rate", 0.0),
         },


### PR DESCRIPTION
## Summary
- rework appearances into log scale with seen flag
- add subtype one-hot encoding and mechanic keyword flags
- use Transformer-based text encoder
- update model test to match new config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c25b4b3308327a73f573329e5f7bc